### PR TITLE
replace to preferred resolver directly

### DIFF
--- a/replacements.txt
+++ b/replacements.txt
@@ -297,7 +297,7 @@ https://www.irs.gov
 (?i)http://www\.sec\.gov
 https://www.sec.gov
 (?i)http://dx\.doi\.org
-https://dx.doi.org
+https://doi.org
 (?i)http://earthquake\.usgs\.gov
 https://earthquake.usgs.gov
 (?i)http://alaska\.usgs\.gov


### PR DESCRIPTION
Hello!

The DOI foundation recommends a [new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) with the `dx`. Have you considered replacing the old, unencrypted links with that?

Also, the reg-ex `(?i)http://dx\.doi\.org` could be broadened to `  (?i)https?://dx\.doi\.org `. Please let me know if I should add such a commit.

Cheers :-)